### PR TITLE
Fix Cloudflare, duckdns and he services to permit multiple different IPv6 addresses in 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Version 3.8.3-TBD (April ??, 2017)
++ Separated IPv6 from IPv4 update status into separate variable
++ Added -max-warn command line option to control number of warning messages
+
 Version 3.8.3-02 (February 18, 2017)
 -----------------------------------
 - Reduce logging that may contain sensitive information in the URL

--- a/ddclient
+++ b/ddclient
@@ -958,7 +958,7 @@ sub update_nics {
 		if (@hosts) {
 			$0 = sprintf("%s - updating %s", $program, join(',', @hosts));
 			&$update(@hosts);
-			runpostscript(join ' ', keys %ips);
+			runpostscript(join ' ', keys %ips, keys %ipsv6);
 		}
 	}
 	foreach my $h (sort keys %config) {

--- a/ddclient
+++ b/ddclient
@@ -416,6 +416,7 @@ my %variables = (
 	'mtime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
 	'atime'               => setv(T_NUMBER, 0, 1, 0, 0,                   undef),
 	'status'              => setv(T_ANY,    0, 1, 0, '',                  undef),
+	'status-ipv6'         => setv(T_ANY,    0, 1, 0, '',                  undef),
 	'min-interval'        => setv(T_DELAY,  0, 0, 1, interval('30s'),     0),
 	'max-interval'        => setv(T_DELAY,  0, 0, 1, interval('25d'),     0),
 	'min-error-interval'  => setv(T_DELAY,  0, 0, 1, interval('5m'),      0),
@@ -2478,7 +2479,7 @@ sub nic_updateable {
 		
     } elsif ((defined($config{$host}{'usev6'}) && ($config{$host}{'usev6'} ne 'no') ) &&
 			 ((!exists($cache{$host}{'ipv6'})) || ("$cache{$host}{'ipv6'}" ne "$ipv6"))) {
-        if (($cache{$host}{'status'} eq 'good') &&
+        if (($cache{$host}{'status-ipv6'} eq 'good') &&
              !interval_expired($host, 'mtime', 'min-interval')) {
             warning("skipping update of %s from %s to %s.\nlast updated %s.\nWait at least %s between update attempts.",
 			 $host,
@@ -2490,7 +2491,7 @@ sub nic_updateable {
             if opt('verbose') || !define($cache{$host}{'warned-min-interval'}, 0);
 				$cache{$host}{'warned-min-interval'} = $now;
 
-        } elsif (($cache{$host}{'status'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
+        } elsif (($cache{$host}{'status-ipv6'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
             warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.",
 			 $host, 
 			 ($cache{$host}{'ipv6'}    ? $cache{$host}{'ipv6'}                : '<nothing>'),
@@ -2530,6 +2531,7 @@ sub nic_updateable {
 		}
     }
     $config{$host}{'status'} = define($cache{$host}{'status'},'');
+    $config{$host}{'status-ipv6'} = define($cache{$host}{'status-ipv6'},'');
     $config{$host}{'update'} = $update;
     if ($update) {
 		$config{$host}{'status'}                    = 'noconnect';
@@ -3855,7 +3857,7 @@ sub nic_freedns_update {
             if($ipv6 eq $freedns_hosts_ipv6{$h}->[1]) {
                 $config{$h}{'ipv6'}     = $ipv6;
                 $config{$h}{'mtime'}  = $now;
-                $config{$h}{'status'} = 'good';
+                $config{$h}{'status-ipv6'} = 'good';
                 success("update not necessary %s: good: IPv6 address already set to %s", $h, $ipv6);
             } else {
                 debug("Update: %s", $freedns_hosts_ipv6{$h}->[2]."&address=".$ipv6);
@@ -3868,10 +3870,10 @@ sub nic_freedns_update {
                 if($reply =~ /Updated.*$h.*to.*$ipv6/) {
                     $config{$h}{'ipv6'}   = $ipv6;
                     $config{$h}{'mtime'}  = $now;
-                    $config{$h}{'status'} = 'good';
+                    $config{$h}{'status-ipv6'} = 'good';
                     success("updating %s: good: IPv6 address set to %s", $h, $ipv6);
                 } else {
-                    $config{$h}{'status'} = 'failed';
+                    $config{$h}{'status-ipv6'} = 'failed';
                     warning("SENT: %s", $freedns_hosts_ipv6{$h}->[2]) unless opt('verbose');
                     warning("REPLIED: %s", $reply);
                     failed("updating %s: Invalid reply.", $h);
@@ -4448,7 +4450,7 @@ sub nic_cloudflare_update {
 				# Cache
 				$config{$key}{'ipv6'}   = $ipv6;
 				$config{$key}{'mtime'}  = $now;
-				$config{$key}{'status'} = 'good';
+				$config{$key}{'status-ipv6'} = 'good';
 			}
 		}
 	}
@@ -4661,7 +4663,7 @@ sub nic_he_update {
                 foreach my $line (@reply) {
                     my ($status, $ipv6_ignore) = split / /, lc $line;
 
-                    $config{$host}{'status'} = $status;
+                    $config{$host}{'status-ipv6'} = $status;
                     if ($status eq 'good') {
                         success("updating %s: IPv6 address set to %s", $host, $ipv6);
                         $config{$host}{'ipv6'}   = $ipv6;
@@ -4672,7 +4674,7 @@ sub nic_he_update {
                             warning("updating %s: No DNS 'AAAA' record update required; %s", $host, $errors{$status});
                             $config{$host}{'ipv6'}   = $ipv6;
                             $config{$host}{'mtime'}  = $now;
-                            $config{$host}{'status'} = 'good';
+                            $config{$host}{'status-ipv6'} = 'good';
 
                         } else {
                             failed("updating %s: %s: %s", $host, $status, $errors{$status});

--- a/ddclient
+++ b/ddclient
@@ -734,6 +734,7 @@ my @opt = (
     [ "retry",       "!",  "-{no}retry            : retry failed updates." ],
     [ "force",       "!",  "-{no}force            : force an update even if the update may be unnecessary" ],
     [ "timeout",     "=i", "-timeout max          : wait at most 'max' seconds for the host to respond" ],
+    [ "max-warn",    "=i", "-max-warn max         : maximum nubmer of warning messages for undefined IP address" ],
 
     [ "syslog",      "!",  "-{no}syslog           : log messages to syslog" ],
     [ "facility",    "=s", "-facility {type}      : log messages to syslog to facility {type}" ],
@@ -763,6 +764,8 @@ my ($result, %config, %globals, %cache);
 my $saved_cache = '';
 my %saved_opt = %opt;
 $result = 'OK';
+my (%warned_ipv4, %warned_ipv6);
+my $inv_ip_warn_count = define(opt('max-warn'),1);
 
 test_geturl(opt('geturl')) if opt('geturl');
 
@@ -2415,6 +2418,14 @@ sub nic_updateable {
     my $ip     = $config{$host}{'wantip'};
     my $ipv6   = $config{$host}{'wantipv6'};
 
+	if (defined($config{$host}{'use'}) && ($config{$host}{'use'} ne 'no') && define($ipv6,0) && define($warned_ipv6{$host},0) ) {
+		$warned_ipv6{$host} = 0;
+		warning("IPv6 address for %s valid: %s. Reset warning count", $host, $ipv6);
+	}
+	if (defined($config{$host}{'usev6'}) && ($config{$host}{'usev6'} ne 'no') && define($ip,0) && define($warned_ipv4{$host},0) ) {
+		$warned_ipv4{$host} = 0;
+		warning("IP address for %s valid: %s. Reset warning count", $host, $ip);
+	}
     if ($config{$host}{'login'} eq '') {
 		warning("null login name specified for host %s.", $host);
 
@@ -2462,16 +2473,21 @@ sub nic_updateable {
 	    
 		} elsif (($cache{$host}{'status'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
 
-			warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.",
-			 $host,
-			 ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'),
-			 $ip,
-			 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
-			 ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
-			 prettyinterval($config{$host}{'min-error-interval'})
-			)
-			if opt('verbose') || !define($cache{$host}{'warned-min-error-interval'}, 0);
-				$cache{$host}{'warned-min-error-interval'} = $now;
+            if (opt('verbose') || (!define($cache{$host}{'warned-min-error-interval'}, 0) && (define($warned_ipv4{$host}, 0) < $inv_ip_warn_count) )) {
+				warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.",
+				 $host,
+				 ($cache{$host}{'ip'}    ? $cache{$host}{'ip'}                : '<nothing>'),
+				 $ip,
+				 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
+				 ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
+				 prettyinterval($config{$host}{'min-error-interval'})
+				);
+				if (!define($ip,0) && !opt('verbose')) {
+					$warned_ipv4{$host} = define($warned_ipv4{$host}, 0) + 1;
+					warning ("IP address for %s undefined. Warned %s times, suppressing further warnings", $host, $inv_ip_warn_count) if ($warned_ipv4{$host} >= $inv_ip_warn_count);
+				}
+			}
+			$cache{$host}{'warned-min-error-interval'} = $now;
 
 		} else {
 			$update = 1;
@@ -2492,16 +2508,21 @@ sub nic_updateable {
 				$cache{$host}{'warned-min-interval'} = $now;
 
         } elsif (($cache{$host}{'status-ipv6'} ne 'good') && !interval_expired($host, 'atime', 'min-error-interval')) {
-            warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.",
-			 $host, 
-			 ($cache{$host}{'ipv6'}    ? $cache{$host}{'ipv6'}                : '<nothing>'),
-			 $ipv6,
-			 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
-			 ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
-			 prettyinterval($config{$host}{'min-error-interval'})
-            )
-            if opt('verbose') || !define($cache{$host}{'warned-min-error-interval'}, 0);
-				$cache{$host}{'warned-min-error-interval'} = $now;
+			if (opt('verbose') || (!define($cache{$host}{'warned-min-error-interval'}, 0) && (define($warned_ipv6{$host}, 0) < $inv_ip_warn_count) )) {
+				warning("skipping update of %s from %s to %s.\nlast updated %s but last attempt on %s failed.\nWait at least %s between update attempts.",
+				 $host,
+				 ($cache{$host}{'ipv6'}    ? $cache{$host}{'ipv6'}                : '<nothing>'),
+				 $ipv6,
+				 ($cache{$host}{'mtime'} ? prettytime($cache{$host}{'mtime'}) : '<never>'),
+				 ($cache{$host}{'atime'} ? prettytime($cache{$host}{'atime'}) : '<never>'),
+				 prettyinterval($config{$host}{'min-error-interval'})
+				);
+				if (!define($ipv6,0) && !opt('verbose')) {
+					$warned_ipv6{$host} = define($warned_ipv6{$host}, 0) + 1;
+					warning ("IPv6 address for %s undefined. Warned %s times, suppressing further warnings", $host, $inv_ip_warn_count) if ($warned_ipv6{$host} >= $inv_ip_warn_count);
+				}
+			}
+			$cache{$host}{'warned-min-error-interval'} = $now;
 
         } else {
             $update = 1;
@@ -3825,7 +3846,7 @@ sub nic_freedns_update {
                 $config{$h}{'ip'}     = $ip;
                 $config{$h}{'mtime'}  = $now;
                 $config{$h}{'status'} = 'good';
-                success("update not necessary %s: good: IPv4 address already set to %s", $h, $ip);
+                success("update not necessary %s: good: IPv4 address already set to %s", $h, $ip) if (!$daemon || opt('verbose'));
             } else {
                 debug("Update: %s", $freedns_hosts{$h}->[2]."&address=".$ip);
                 my $reply = geturl(opt('proxy'), $freedns_hosts{$h}->[2]."&address=".$ip);
@@ -3858,7 +3879,7 @@ sub nic_freedns_update {
                 $config{$h}{'ipv6'}     = $ipv6;
                 $config{$h}{'mtime'}  = $now;
                 $config{$h}{'status-ipv6'} = 'good';
-                success("update not necessary %s: good: IPv6 address already set to %s", $h, $ipv6);
+                success("update not necessary %s: good: IPv6 address already set to %s", $h, $ipv6) if (!$daemon || opt('verbose'));
             } else {
                 debug("Update: %s", $freedns_hosts_ipv6{$h}->[2]."&address=".$ipv6);
                 my $reply = geturl(opt('proxy'), $freedns_hosts_ipv6{$h}->[2]."&address=".$ipv6);

--- a/ddclient
+++ b/ddclient
@@ -4377,8 +4377,6 @@ sub nic_cloudflare_update {
         my @hosts = @{$groups{$sig}};
         my $hosts = join(',', @hosts);
         my $key   = $hosts[0];
-        my $ip    = $config{$key}{'wantip'};
-        my $ipv6  = $config{$key}{'wantipv6'};
 
         my $headers = "X-Auth-Email: $config{$key}{'login'}\n";
         $headers .= "X-Auth-Key: $config{$key}{'password'}\n";
@@ -4387,8 +4385,8 @@ sub nic_cloudflare_update {
         # FQDNs
         for my $domain (@hosts) {
             (my $hostname = $domain) =~ s/\.$config{$key}{zone}$//;
-            delete $config{$domain}{'wantip'};
-            delete $config{$domain}{'wantipv6'};
+            my $ip    = delete $config{$domain}{'wantip'};
+            my $ipv6  = delete $config{$domain}{'wantipv6'};
 
             info("getting Cloudflare Zone ID for %s", $domain);
 
@@ -4458,9 +4456,9 @@ sub nic_cloudflare_update {
                 }
 
                 # Cache
-                $config{$key}{'ip'}     = $ip;
-                $config{$key}{'mtime'}  = $now;
-                $config{$key}{'status'} = 'good';
+                $config{$domain}{'ip'}     = $ip;
+                $config{$domain}{'mtime'}  = $now;
+                $config{$domain}{'status'} = 'good';
             }
 
             if (defined($ipv6)) {
@@ -4506,9 +4504,9 @@ sub nic_cloudflare_update {
                 }
 
                 # Cache
-                $config{$key}{'ipv6'}        = $ipv6;
-                $config{$key}{'mtime'}       = $now;
-                $config{$key}{'status-ipv6'} = 'good';
+                $config{$domain}{'ipv6'}        = $ipv6;
+                $config{$domain}{'mtime'}       = $now;
+                $config{$domain}{'status-ipv6'} = 'good';
             }
         }
     }
@@ -4558,13 +4556,11 @@ sub nic_duckdns_update {
     foreach my $sig (keys %groups) {
         my @hosts = @{$groups{$sig}};
         my $key   = $hosts[0];
-        my $ip    = $config{$key}{'wantip'};
-        my $ipv6  = $config{$key}{'wantipv6'};
 
         # FQDNs
         for my $host (@hosts) {
-            delete $config{$host}{'wantip'};
-            delete $config{$host}{'wantipv6'};
+            my $ip    = delete $config{$host}{'wantip'};
+            my $ipv6  = delete $config{$host}{'wantipv6'};
 
             my $nq_host = $host;
             $nq_host =~ s/\.duckdns\.org$//;
@@ -4684,13 +4680,11 @@ sub nic_he_update {
     foreach my $sig (keys %groups) {
         my @hosts = @{$groups{$sig}};
         my $key   = $hosts[0];
-        my $ip    = $config{$key}{'wantip'};
-        my $ipv6  = $config{$key}{'wantipv6'};
 
         # FQDNs
         for my $host (@hosts) {
-            delete $config{$host}{'wantip'};
-            delete $config{$host}{'wantipv6'};
+            my $ip    = delete $config{$host}{'wantip'};
+            my $ipv6  = delete $config{$host}{'wantipv6'};
 
             if (defined($ip)) {
                 info("setting IPv4 address to %s for %s", $ip, $host);


### PR DESCRIPTION
Lonnie, this is update to allow multiple different IPv6 addresses for different subdomains.  So if you have exmaple.com, a.example.com, b.example.com and all of them have different IPv6 addresses then they will be correctly set at Cloudflare, and correctly cached (found a problem with that when testing). 

Similar problem exist with duckdns and he.  I have made code change to address those as well, but not tested.  In reviewing the code they should not have the cache problem.

This PR seems to drag other commits, which amount to no changes because I think you cherrypicked them last year.  Maybe you should just cherrypick this one commit rather than take the PR.  Then I can delete the branch which will clean up for any future PRs.
David